### PR TITLE
feat: Adjust entropy and padding in Contract Context #96

### DIFF
--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -66,8 +66,8 @@ async function getContext(contractAddress: string): Promise<Context> {
   const address = getAddress();
   const key = viewingKeyManager.get(contractAddress);
   const height = await getHeight();
-  const padding = getEntropyString(12);
-  const entropy = getEntropyString(12);
+  const padding = getEntropyString(32);
+  const entropy = window.btoa(getEntropyString(32));
 
   // Set the context.
   return { address, key, height, padding, entropy } as Context;


### PR DESCRIPTION
Changes: 

`padding` make it 32 length
`entropy` make it 32 length and encode it to base64

#96 