### PR TITLE
fix: inherit query permit values

### DIFF
--- a/src/auth/permits.ts
+++ b/src/auth/permits.ts
@@ -145,7 +145,7 @@ export async function enablePermit(
 
     if (!keplr) throw new Error('No keplr is available');
 
-    const { signature } = await keplr.signAmino(
+    const { signed, signature } = await keplr.signAmino(
       chainId,
       address,
       {
@@ -174,12 +174,14 @@ export async function enablePermit(
       }
     );
 
+    let signedPermit = signed.msgs[0].value;
+
     let permit = {
       params: {
-        permit_name: permitName,
-        allowed_tokens: allowedTokens,
         chain_id: chainId,
-        permissions: permissions,
+        permit_name: signedPermit.permit_name,
+        allowed_tokens: signedPermit.allowed_tokens,
+        permissions: signedPermit.permissions,
       },
       signature: signature,
     };


### PR DESCRIPTION
This PR fixes wallet compatibility issues with signing query permits.

The issue with the current implementation is that it assumes the signature that the wallet returns is for the Amino document it requested. However, the API contract allows returning a signDoc that is different: https://cosmos.github.io/cosmjs/latest/amino/interfaces/AminoSignResponse.html#signed
> signed: [StdSignDoc](https://cosmos.github.io/cosmjs/latest/amino/interfaces/StdSignDoc.html)
> The sign doc that was signed. This may be different from the input signDoc when the signer modifies it as part of the signing process.

This is important for few reasons, but i'll just stick with the primary 

#### Canonicalization
Wallets (such as StarShell) should be allowed to canonicalize query permit requests in order to prevent signing redundant query permits. For example, the wallet may choose to sort the values of the `allowed_tokens` array or the `permissions` array. From a modeling perspective, these values are actually sets, so order should not matter. The wallet should therefore be able to sort the items in these sets (JSON arrays) when storing them internally in order to canonicalize the signed query permit, making it possible to recall existing permits even if a different app presents the same set of tokens but in a different order.

#### User Control
End users should actually have the final say over the signed document, including making changes to the suggested query permit. For instance, if a user previously revoked a query permit from a given dApp and they wish to sign a new permit, the current implementation would block them from doing so since the revoked permit name cannot be changed. However, if griptape simply used the signed permit returned by the Keplr API, the user would be able to change the suggested permit name in order to not conflict with the previously revoked permit.