### PR TITLE
fix: use actual signed data when returning permit

### DIFF
--- a/src/auth/permits.ts
+++ b/src/auth/permits.ts
@@ -44,7 +44,7 @@ export class PermitManager extends AccountManager {
 
       if (!keplr) throw new Error('No keplr is available');
 
-      const { signature } = await keplr.signAmino(
+      const { signed, signature } = await keplr.signAmino(
         chainId,
         address,
         {
@@ -73,12 +73,14 @@ export class PermitManager extends AccountManager {
         }
       );
 
+      let signedPermit = signed.msgs[0].value;
+
       let permit = {
         params: {
-          permit_name: permitName,
-          allowed_tokens: allowedTokens,
           chain_id: chainId,
-          permissions: permissions,
+          permit_name: signedPermit.permit_name,
+          allowed_tokens: signedPermit.allowed_tokens,
+          permissions: signedPermit.permissions,
         },
         signature: signature,
       };


### PR DESCRIPTION
This should have been part of #196 but I must have missed it, my apologies! I don't see any other calls to signAmino so this should be the last of this issue.